### PR TITLE
Add Tracking for Physical Actions

### DIFF
--- a/src/main/java/com/emicb/containertracker/ContainerTracker.java
+++ b/src/main/java/com/emicb/containertracker/ContainerTracker.java
@@ -1,5 +1,6 @@
 package com.emicb.containertracker;
 
+import com.emicb.containertracker.commands.ToggleDebug;
 import com.emicb.containertracker.listeners.InventoryCloseListener;
 import com.emicb.containertracker.utils.sql.Queryer;
 import org.bukkit.Bukkit;
@@ -9,35 +10,49 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.logging.Logger;
 
 public final class ContainerTracker extends JavaPlugin {
+    private static ContainerTracker plugin;
     private Queryer queryer;
+
     @Override
     public void onEnable() {
         // Plugin startup logic
         saveDefaultConfig();
         PluginManager pluginManager = Bukkit.getPluginManager();
+        plugin = this;
 
         // Set up logger
         Logger log = Logger.getLogger("Minecraft");
-        log.info("[ContainerTracker] Hello world!");
+
         this.queryer = new Queryer(this, q -> {
             // If we couldn't connect to the database disable the plugin
             if (q == null) {
-                this.getLogger().severe("Could not establish MySQL connection! Disabling plugin...");
+                log.severe("[ContainerTracker] Could not establish MySQL connection! Disabling plugin...");
                 getCommand("progress").setExecutor(this);
                 getCommand("leaderboard").setExecutor(this);
                 return;
             }
-
-
         });
+
         // Link listeners
-        pluginManager.registerEvents(new InventoryCloseListener(this), this);
+        pluginManager.registerEvents(new InventoryCloseListener(), this);
+
+        // Link commands
+        // TODO: change command structure to sub-commands
+        getServer().getPluginCommand("ct-toggle-debug").setExecutor(new ToggleDebug());
+        // TODO: add enable / disable logging commands
+
+        log.info("[ContainerTracker] Started successfully!");
     }
-    public Queryer getQueryer() {
-        return this.queryer;
-    }
+
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+    }
+
+    public static ContainerTracker getInstance() {
+        return plugin;
+    }
+    public Queryer getQueryer() {
+        return this.queryer;
     }
 }

--- a/src/main/java/com/emicb/containertracker/ContainerTracker.java
+++ b/src/main/java/com/emicb/containertracker/ContainerTracker.java
@@ -2,6 +2,7 @@ package com.emicb.containertracker;
 
 import com.emicb.containertracker.commands.ToggleDebug;
 import com.emicb.containertracker.listeners.InventoryCloseListener;
+import com.emicb.containertracker.listeners.PlayerInteractListener;
 import com.emicb.containertracker.utils.sql.Queryer;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
@@ -35,6 +36,7 @@ public final class ContainerTracker extends JavaPlugin {
 
         // Link listeners
         pluginManager.registerEvents(new InventoryCloseListener(), this);
+        pluginManager.registerEvents(new PlayerInteractListener(), this);
 
         // Link commands
         // TODO: change command structure to sub-commands

--- a/src/main/java/com/emicb/containertracker/commands/ToggleDebug.java
+++ b/src/main/java/com/emicb/containertracker/commands/ToggleDebug.java
@@ -1,0 +1,22 @@
+package com.emicb.containertracker.commands;
+
+import com.emicb.containertracker.ContainerTracker;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class ToggleDebug implements CommandExecutor {
+    // Set up config
+    FileConfiguration config = ContainerTracker.getInstance().getConfig();
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        // TODO: add permission guards
+
+        // flip the debug boolean
+        config.set("debug", !config.getBoolean("debug"));
+
+        return true;
+    }
+}

--- a/src/main/java/com/emicb/containertracker/listeners/InventoryCloseListener.java
+++ b/src/main/java/com/emicb/containertracker/listeners/InventoryCloseListener.java
@@ -2,6 +2,7 @@ package com.emicb.containertracker.listeners;
 
 import com.emicb.containertracker.ContainerTracker;
 import org.bukkit.block.Container;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -13,15 +14,16 @@ import java.util.ArrayList;
 import java.util.logging.Logger;
 
 public class InventoryCloseListener implements Listener {
-    private ContainerTracker plugin;
-    public InventoryCloseListener(ContainerTracker plugin){
-        this.plugin = plugin;
-    }
+    // Set up config
+    private final FileConfiguration config = ContainerTracker.getInstance().getConfig();
+
     @EventHandler
     public void OnInventoryClose(InventoryCloseEvent event) {
         // Set up logger
         Logger log = Logger.getLogger("Minecraft");
-        log.info("[ContainerTracker] inventory close event!");
+        if (config.getBoolean("debug")) {
+            log.info("[ContainerTracker] inventory close event!");
+        }
 
         Inventory inventory = event.getInventory();
         Player sender = (Player) event.getPlayer();
@@ -34,19 +36,24 @@ public class InventoryCloseListener implements Listener {
         Container container = (Container) inventory.getHolder();
 
         // Get data to store
-        log.info("[ContainerTracker] logging information:\n"
-                + "timestamp: " + System.currentTimeMillis() + "\n"
-                + "player: " + event.getPlayer().getName() + " : " + event.getPlayer().getUniqueId() + "\n"
-                + "location: " + container.getLocation()
-        );
+        if (config.getBoolean("debug")) {
+            log.info("[ContainerTracker] logging information:\n"
+                    + "timestamp: " + System.currentTimeMillis() + "\n"
+                    + "player: " + event.getPlayer().getName() + " : " + event.getPlayer().getUniqueId() + "\n"
+                    + "location: " + container.getLocation()
+            );
+        }
 
         // Get inventory contents
         ItemStack[] contents = inventory.getContents();
         if (contents.length == 0) {
-            log.info("[ContainerTracker] Container is empty!");
+            if (config.getBoolean("debug")) {
+                log.info("[ContainerTracker] Container is empty!");
+            }
+
             return;
         }
-        this.plugin.getQueryer().storeNewInventory(sender, contents);
 
+        ContainerTracker.getInstance().getQueryer().storeNewInventory(sender, contents);
     }
 }

--- a/src/main/java/com/emicb/containertracker/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/emicb/containertracker/listeners/PlayerInteractListener.java
@@ -10,28 +10,34 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import java.util.logging.Logger;
 
 public class PlayerInteractListener implements Listener {
+    // Set up config
+    private final FileConfiguration config = ContainerTracker.getInstance().getConfig();
+
+    // Set up logger
+    private final Logger log = Logger.getLogger("Minecraft");
+
     @EventHandler
     public void OnPlayerInteract(PlayerInteractEvent event) {
-        // Set up config
-        FileConfiguration config = ContainerTracker.getInstance().getConfig();
-
-        // Set up logger
-        Logger log = Logger.getLogger("Minecraft");
         if (config.getBoolean("debug")) {
             log.info("[ContainerTracker] player interact event!");
         }
 
+        // exit if not a physical interaction
         if (event.getAction() != Action.PHYSICAL) {
             return;
         }
 
-        // TODO: Add these results to DB
         if (config.getBoolean("debug")) {
             log.info("[ContainerTracker] logging information:\n"
                     + "timestamp: " + System.currentTimeMillis() + "\n"
                     + "player: " + event.getPlayer().getName() + " : " + event.getPlayer().getUniqueId() + "\n"
                     + "location: " + event.getPlayer().getLocation()
             );
+            log.info(event.getClickedBlock().getType().toString());
         }
+
+        // Add results to the database
+        ContainerTracker.getInstance().getQueryer().logNewPhysicalInteraction(event.getPlayer(), event.getClickedBlock());
+
     }
 }

--- a/src/main/java/com/emicb/containertracker/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/emicb/containertracker/listeners/PlayerInteractListener.java
@@ -1,0 +1,37 @@
+package com.emicb.containertracker.listeners;
+
+import com.emicb.containertracker.ContainerTracker;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.util.logging.Logger;
+
+public class PlayerInteractListener implements Listener {
+    @EventHandler
+    public void OnPlayerInteract(PlayerInteractEvent event) {
+        // Set up config
+        FileConfiguration config = ContainerTracker.getInstance().getConfig();
+
+        // Set up logger
+        Logger log = Logger.getLogger("Minecraft");
+        if (config.getBoolean("debug")) {
+            log.info("[ContainerTracker] player interact event!");
+        }
+
+        if (event.getAction() != Action.PHYSICAL) {
+            return;
+        }
+
+        // TODO: Add these results to DB
+        if (config.getBoolean("debug")) {
+            log.info("[ContainerTracker] logging information:\n"
+                    + "timestamp: " + System.currentTimeMillis() + "\n"
+                    + "player: " + event.getPlayer().getName() + " : " + event.getPlayer().getUniqueId() + "\n"
+                    + "location: " + event.getPlayer().getLocation()
+            );
+        }
+    }
+}

--- a/src/main/java/com/emicb/containertracker/utils/sql/Queryer.java
+++ b/src/main/java/com/emicb/containertracker/utils/sql/Queryer.java
@@ -5,6 +5,7 @@ import com.emicb.containertracker.utils.Utils;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -31,7 +32,11 @@ public class Queryer {
 
     private final ContainerTracker plugin;
     private final MySQLConnection sqlConnection;
-    private  Logger log;
+    private Logger log;
+
+    // Set up config
+    private final FileConfiguration config = ContainerTracker.getInstance().getConfig();
+
     /**
      * Constructor to instantiate instance variables and connect to SQL
      * @param plugin StudentFeedback plugin instance
@@ -69,21 +74,27 @@ public class Queryer {
             ItemStack item = contents[i];
             //Safety check for larger chests can't store in our db
             if(i >= CHEST_SIZE){
-                log.info("[ContainerTracker] slot " + i + " is larger than what can be stored in the db and won't be tracked");
+                if (config.getBoolean("debug")) {
+                    log.info("[ContainerTracker] slot " + i + " is larger than what can be stored in the db and won't be tracked");
+                }
                 net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
                 NBTTagCompound tag = nmsItem.v();
-                if (item == null) {
+                if (item == null && config.getBoolean("debug")) {
                     log.info("[ContainerTracker] slot " + i + " has: nothing");
-                } else if(tag != null){
+                } else if (tag != null && config.getBoolean("debug")) {
                     log.info("[ContainerTracker] slot " + i + " has: " + tag);
                 } else {
-                    log.info("[ContainerTracker] slot " + i + " has: " + nmsItem);
+                    if (config.getBoolean("debug")) {
+                        log.info("[ContainerTracker] slot " + i + " has: " + nmsItem);
+                    }
                 }
                 continue;
             }
 
             if (item == null) {
-                log.info("[ContainerTracker] slot " + i + " has: nothing");
+                if (config.getBoolean("debug")) {
+                    log.info("[ContainerTracker] slot " + i + " has: nothing");
+                }
                 statement.setString(i+8, null);
                 continue;
             }
@@ -104,10 +115,14 @@ public class Queryer {
                 int indexColon = text.indexOf(':');
                 int indexComma = text.indexOf(',');
                 text = text.substring(indexColon + 1, indexComma);
-                log.info("[ContainerTracker] slot " + i + " has: " + tag);
+                if (config.getBoolean("debug")) {
+                    log.info("[ContainerTracker] slot " + i + " has: " + tag);
+                }
                 statement.setString(i + 8, text);
             } else {
-                log.info("[ContainerTracker] slot " + i + " has: " + nmsItem);
+                if (config.getBoolean("debug")) {
+                    log.info("[ContainerTracker] slot " + i + " has: " + nmsItem);
+                }
                 statement.setString(i + 8, nmsItem.toString());
             }
         }
@@ -128,15 +143,15 @@ public class Queryer {
                     String query = statement.toString().substring(statement.toString().indexOf(" ") + 1);
                     Utils.debug("  " + query);
                     statement.executeUpdate();
-                    log.info("Inventory has been stored!");
+                    if (config.getBoolean("debug")) {
+                        log.info("Inventory has been stored!");
+                    }
                 }
             } catch (SQLException e) {
                 e.printStackTrace();
             }
         });
     }
-
-
 
     private <T> void sync(Consumer<T> cons, T val) {
         Bukkit.getScheduler().runTask(this.plugin, () -> cons.accept(val));
@@ -149,6 +164,4 @@ public class Queryer {
     private void async(Runnable runnable) {
         Bukkit.getScheduler().runTaskAsynchronously(this.plugin, runnable);
     }
-
-
 }

--- a/src/main/java/com/emicb/containertracker/utils/sql/migration/schemas/Schema_2.java
+++ b/src/main/java/com/emicb/containertracker/utils/sql/migration/schemas/Schema_2.java
@@ -67,7 +67,7 @@ public class Schema_2  extends SchemaVersion {
      * Constructor to specify which migrations to do
      */
     public Schema_2() {
-        super(2, null);
+        super(2, new Schema_3());
     }
 
     /**

--- a/src/main/java/com/emicb/containertracker/utils/sql/migration/schemas/Schema_3.java
+++ b/src/main/java/com/emicb/containertracker/utils/sql/migration/schemas/Schema_3.java
@@ -1,0 +1,43 @@
+package com.emicb.containertracker.utils.sql.migration.schemas;
+
+import com.emicb.containertracker.utils.sql.migration.SchemaVersion;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class Schema_3 extends SchemaVersion {
+
+    private static final String CREATE_TABLE =
+            "CREATE TABLE IF NOT EXISTS `whimc_action_physical` (" +
+                    "  `rowid`       INT    AUTO_INCREMENT NOT NULL," +
+                    "  `uuid`        VARCHAR(36)           NOT NULL," +
+                    "  `username`    VARCHAR(16)           NOT NULL," +
+                    "  `world`       VARCHAR(36)           NOT NULL," +
+                    "  `x`           DOUBLE                NOT NULL," +
+                    "  `y`           DOUBLE                NOT NULL," +
+                    "  `z`           DOUBLE                NOT NULL," +
+                    "  `time`        BIGINT                NOT NULL," +
+                    "  `type`        VARCHAR(36)           NOT NULL," +
+                    "  PRIMARY KEY   (`rowid`));";
+
+    /**
+     * Constructor to specify which migrations to do
+     */
+    protected Schema_3() {
+        super(3, null);
+    }
+
+    /**
+     * Method to migrate SQL
+     * @param connection SQL connection
+     */
+    @Override
+    protected void migrateRoutine(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(CREATE_TABLE)) {
+            statement.execute();
+        } catch (Exception e){
+
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,4 @@
+debug: true
 mysql:
   host: localhost
   port: 3306

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,8 @@ name: ContainerTracker
 version: '${project.version}'
 main: com.emicb.containertracker.ContainerTracker
 api-version: 1.20
+
+commands:
+  ct-toggle-debug:
+    description: toggles debug mode for ContainerTracker
+    usage: /<command>


### PR DESCRIPTION
Adds a database and tracking for [`Action.PHYSICAL`](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/block/Action.html#PHYSICAL) events.

Examples of `Action.PHYSICAL`:
- Jumping on soil
- Standing on pressure plate
- Triggering redstone ore
- Triggering tripwire

Note: weighted pressure plate and redstone ore interactions will spam the database as the event is called for every game loop the player is triggering them